### PR TITLE
docs: Add links to talk and workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# talk-software-citation-workshop-2022
-Talk at the Software Citation and Recognition in HEP workshop on tools and best practices
+# [Software Citation Tools, Technologies, and Best Practices](https://indico.cern.ch/event/1211229/contributions/5120858/)
+
+Talk given at the [2022 Software Citation and Recognition in HEP workshop](https://indico.cern.ch/event/1211229/).
+
+Viewable online [here](https://matthewfeickert-talks.github.io/talk-software-citation-workshop-2022/).


### PR DESCRIPTION
* Add links to the 2022 software citation workshop to README
   - c.f. https://indico.cern.ch/event/1211229/